### PR TITLE
adds atmos gas mask to atmos suit storages

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -64,7 +64,7 @@
 
 /obj/machinery/suit_storage_unit/atmos
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine/atmos
-	mask_type = /obj/item/clothing/mask/gas
+	mask_type = /obj/item/clothing/mask/gas/atmos
 	storage_type = /obj/item/watertank/atmos
 
 /obj/machinery/suit_storage_unit/mining


### PR DESCRIPTION

# Document the changes in your pull request

adds atmos gasmask to atmos suitstorage

# Spriting

# Wiki Documentation

mention it in the atmos wiki
...i guess?...
# Changelog


:cl:  
rscadd: atmos gas masks in suit storage
mapping: atmosgasmasks in suitstorage

/:cl:
